### PR TITLE
quick and dirty fixed of duplicated node label after midpoint

### DIFF
--- a/R/treeManipulation.R
+++ b/R/treeManipulation.R
@@ -140,7 +140,23 @@ node2root <- function(x){
     attr(tree, "order") <- NULL
     tree <- reorder(reroot(tree, rn), "postorder")
     if(!is.null(oldtree$node.label))tree <- addConfidences.phylo(tree, oldtree)
-    tree 
+
+    if (!is.null(tree$node.label)) {
+        dnode <- tree$node[duplicated(tree$node)]
+        oldtip1 <- oldtree$tip.label[1]
+        tip1 <- which(tree$tip.label == oldtip1)
+        
+        old_dnode_id <- nTips + which(oldtree$node.label == dnode)
+        dnode_id <- nTips + which(tree$node.label == dnode)
+        
+        is_offspring_old <- old_dnode_id %in% Ancestors(oldtree, 1, 'all')
+        is_offspring <- dnode_id %in% Ancestors(tree, tip1, 'all')
+        
+        idx <- which(is_offspring_old != is_offspring)
+        tree$node.label[tree$node.label == dnode][idx] <- oldtree$node.label[! oldtree$node.label %in% tree$node.label]
+    }
+    
+    reorder(tree)
 }
 
 

--- a/R/treeManipulation.R
+++ b/R/treeManipulation.R
@@ -153,7 +153,12 @@ node2root <- function(x){
         is_offspring <- dnode_id %in% Ancestors(tree, tip1, 'all')
         
         idx <- which(is_offspring_old != is_offspring)
-        tree$node.label[tree$node.label == dnode][idx] <- oldtree$node.label[! oldtree$node.label %in% tree$node.label]
+        missing_lab <- oldtree$node.label[! oldtree$node.label %in% tree$node.label]
+        if (length(missing_lab) == 0 ) {
+            tree$node.label[tree$node.label == dnode][idx] <- ""
+        } else {
+            tree$node.label[tree$node.label == dnode][idx] <- missing_lab
+        }
     }
     
     reorder(tree)


### PR DESCRIPTION
referring to [https://github.com/KlausVigo/phangorn/issues/5](https://github.com/KlausVigo/phangorn/issues/5), I try to figure out the reason. Unfortunately, I can figure out the logic behind `addConfidences`.

Here is a quick and dirty hack trying to fixed the issue before `return(tree)` by identifying the duplicated label and correct it (hopefully).

```r
> set.seed(123)
> tree=rtree(30)
> tree$node.label <- paste0('X', 1:29)
> mtr <- phangorn:::midpoint(tree)
> mtr2 <- midpoint(tree)
> p <- ggtree(tree) + geom_label(aes(label=label)) + ggtitle("original")
> p1 <- ggtree(reorder(mtr)) + geom_label(aes(label=label)) + ggtitle("midpoint")
> p2 <- ggtree(mtr2) + geom_label(aes(label=label)) + ggtitle("midpoint2")
> grid.arrange(p, p1, p2, ncol=3)
```

![screenshot 2015-11-24 16 47 01](https://cloud.githubusercontent.com/assets/626539/11361980/dd00cd0a-92cb-11e5-8dd2-d5c4cb1c7292.png)
