### PR TITLE
Update treedist.R

### DIFF
--- a/R/treedist.R
+++ b/R/treedist.R
@@ -324,7 +324,7 @@ wRF1 <- function(trees, normalize=FALSE, check.labels = TRUE){
         }
     }
     attr(wRF, "Size") <- l
-    if(!is.null(names(trees)))attr(KF, "Labels") <- names(trees)
+    if(!is.null(names(trees)))attr(wRF, "Labels") <- names(trees)
     attr(wRF, "Diag") <- FALSE
     attr(wRF, "Upper") <- FALSE
     class(wRF) <- "dist"


### PR DESCRIPTION
For a set of trees with name attributes, wRF.dist was returning the error:
`Error in wRF1(tree1, check.labels) : object 'KF' not found`
I think "KF" was a copy-pasting error from KF.dist; suggest changing to "wRF".