### PR TITLE
Compare seq-gen and phangorn::simSeq, fix #46

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ bioc_packages:
 env:
   - WARNINGS_ARE_ERRORS=false
   - NOT_CRAN=true
+
+before_script:
+  - sudo apt install seq-gen

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: r
 sudo: required
+
+r_packages:
+  - devtools
+
 bioc_required: true
 
 bioc_packages:


### PR DESCRIPTION
As discussed at [issue 46](https://github.com/KlausVigo/phangorn/issues/46), I have added a test that compares seq-gen and phangorn::simSeq. You can observe it uses a Kolmogorov-Smirnoff test to confirm the distributions are similar [*].

I only test for DNA and the Jukes-Cantor nucleotide substitution model.

I followed your coding style as much as I could.

Cheers, Richel

[*]: formally one should say: one cannot reject the null-hypothesis the two distributions of values are drawn from the same distribution.