### PR TITLE
Expose bug in densiTree

### DIFF
--- a/tests/testthat/test_densiTree.R
+++ b/tests/testthat/test_densiTree.R
@@ -1,7 +1,13 @@
 context("densiTree")
 
+test_that("minimal use", {
+  phylogeny_1 <- ape::read.tree(text = "((A:2, B:2):1, C:3);")
+  phylogeny_2 <- ape::read.tree(text = "((A:1, B:1):2, C:3);")
+  trees <- c(phylogeny_1, phylogeny_2)
 
-
+  # Fails, with error 'Error in temp[[j + 1]] : subscript out of bounds'
+  testthat::expect_silent(densiTree(trees))
+})
 
 # Visual tests ------------------------------------------------------------
 test_that("visual appearance", {


### PR DESCRIPTION
Hi @KlausVigo,

Here I submit a Pull Request that exposes a bug in densiTree. Sure, I can add a

```
skip("Not now")
```

as the first line of the test, but I prefer to show this test fails first.

I hope this helps you to get the bug fixed :+1: