### PR TITLE
Fix #65

### DIFF
--- a/R/Densi.R
+++ b/R/Densi.R
@@ -139,7 +139,7 @@ densiTree <- function(x, type = "cladogram", alpha = 1 / length(x),
     consensus$edge.length <- rep(1.0, nrow(consensus$edge))
   }
   if (is.null(consensus)) {
-    consensus <- tryCatch(consensus(x, p = .5),
+    consensus <- tryCatch(ape::consensus(x, p = .5),
                           error = function(e) unroot(midpoint(superTree(x))))
   }
   if (inherits(consensus, "multiPhylo")) consensus <- consensus[[1]]

--- a/tests/testthat/test_densiTree.R
+++ b/tests/testthat/test_densiTree.R
@@ -1,7 +1,13 @@
 context("densiTree")
 
+test_that("minimal use", {
+  phylogeny_1 <- ape::read.tree(text = "((A:2, B:2):1, C:3);")
+  phylogeny_2 <- ape::read.tree(text = "((A:1, B:1):2, C:3);")
+  trees <- c(phylogeny_1, phylogeny_2)
 
-
+  # Fails, with error 'Error in temp[[j + 1]] : subscript out of bounds'
+  testthat::expect_silent(densiTree(trees))
+})
 
 # Visual tests ------------------------------------------------------------
 test_that("visual appearance", {

--- a/tests/testthat/test_densiTree.R
+++ b/tests/testthat/test_densiTree.R
@@ -6,7 +6,7 @@ test_that("minimal use", {
   trees <- c(phylogeny_1, phylogeny_2)
 
   # Fails, with error 'Error in temp[[j + 1]] : subscript out of bounds'
-  testthat::expect_silent(densiTree(trees))
+  testthat::expect_silent(phangorn::densiTree(trees))
 })
 
 # Visual tests ------------------------------------------------------------
@@ -14,10 +14,10 @@ test_that("visual appearance", {
     skip_on_cran()
     data(Laurasiatherian)
     set.seed(1)
-    bs_trees <- bootstrap.phyDat(subset(Laurasiatherian, 1:10), FUN = 
+    bs_trees <- bootstrap.phyDat(subset(Laurasiatherian, 1:10), FUN =
                                      function(x) upgma(dist.hamming(x)), bs=5)
-    densiT <- function() densiTree(bs_trees, type="phylogram", scale.bar=FALSE, 
+    densiT <- function() densiTree(bs_trees, type="phylogram", scale.bar=FALSE,
                         width=2, jitter=list(amount=.3, random=FALSE), alpha=1)
-    
+
     vdiffr::expect_doppelganger("densiTree plot", densiT)
 })


### PR DESCRIPTION
Allows user to call `phangorn::densiTree` without doing `library(ape)` first. In this way, it always works.