### PR TITLE
Memory leak in C_sprdist

### DIFF
--- a/src/sprdist.c
+++ b/src/sprdist.c
@@ -212,6 +212,10 @@ del_splitset (splitset split)
     for (i = split->size - 1; i >= 0; i--) del_bipartition (split->g_split[i]);
     free (split->g_split);
   }
+  if (split->s_split) {
+    for (i = split->size - 1; i >= 0; i--) del_bipartition (split->s_split[i]);
+    free (split->s_split);
+  }
   del_hungarian (split->h);
   free (split);
 }


### PR DESCRIPTION
I am encountering a memory leak when I use SPR.dist to compare large numbers of trees.  Over time, all my RAM is consumed.

```
set.seed(1)
for (i in 1:1000) {
  cat('.')
  trees <- lapply(rep(40, 50), ape::rtree, br = NULL)
  # If trees are not re-ordered, then path.dist often crashes
  trees <- structure(lapply(trees, TreeTools::Postorder), class='multiPhylo')
  phangorn::SPR.dist(trees)
}
```

From a very brief glance at the code, I notice that split->s_split seems to be `malloc`ed, but never `free`d; a possible fix to this issue is proposed.  But it is probably worth taking a more careful and detailed look at the code than this to check that there are not additional leaks.