### PR TITLE
Document `Q` normalization

### DIFF
--- a/R/simSeq.R
+++ b/R/simSeq.R
@@ -30,7 +30,9 @@
 #' @param x a phylogenetic tree \code{tree}, i.e. an object of class
 #' \code{phylo} or and object of class \code{pml}.
 #' @param l The length of the sequence to simulate.
-#' @param Q The rate matrix.
+#' @param Q A numeric matrix of size Nstates &times; Nstates, giving the
+#' transition rates between sites. Every row must sum to zero. `simSeq` will
+#' normalize the given rates so that each row sums to one.
 #' @param bf Base frequencies.
 #' @param rootseq A vector of length \code{l} containing the root sequence.
 #' If not provided, the root sequence is randomly generated.


### PR DESCRIPTION
I noticed that `phangorn::simSeq()` was simulating matrices with different properties to `castor::simulate_mk_model()`.  The reason is that `simSeq` normalizes the provided `Q` matrix, whereas `simulate_mk_model` uses the unnormalized matrix.

It took me a while to spot this; I've proposed this edit to the documentation so that this is obvious to future users.

(I've not run `devtools::document()` to cascade this into the compiled Rd files.)


